### PR TITLE
ci: don't repeat tests on merge to main

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,8 @@ name: "CI"
 
 on:
   push:
+    branches-ignore:
+      - main # Use branch protection rule for main that require status checks to pass before merging
 
 jobs:
   build:


### PR DESCRIPTION
We use branch protection rule on main that requires the tests to pass, so no need to run them again on merge to main.