### PR TITLE
chore: add scm compliance badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PEPM-UI
+[![SCM Compliance](https://scm-compliance-api.radix.equinor.com/repos/equinor/pepm-ui/badge)](https://scm-compliance-api.radix.equinor.com/repos/equinor/pepm-ui/badge)
 
 User Interface for **Parameter Estimation from Process Models**.
 


### PR DESCRIPTION
In order to ensure compliance with the Equinor SCM Policy, a badge is available for use in repositories. The badge is a visual indicator that the repository is compliant with the Equinor SCM Policy.