### PR TITLE
chore: Update Object result compute type.

### DIFF
--- a/src/features/Results/CaseResult/CaseResultView/CaseResultView.tsx
+++ b/src/features/Results/CaseResult/CaseResultView/CaseResultView.tsx
@@ -14,27 +14,16 @@ export const CaseResultView = ({
   channelResultList,
   variogramResultList,
   computeCases,
+  type,
 }: {
   channelResultList?: GetObjectResultsDto[];
   variogramResultList?: GetVariogramResultsDto[];
   computeCases?: ComputeCaseDto[];
+  type: string;
 }) => {
-  const channelType =
-    channelResultList !== undefined && channelResultList[0].type
-      ? channelResultList[0].type
-      : '';
-  const variogramType = variogramResultList !== undefined ? 'Variogram' : '';
-
   return (
     <Styled.CaseResultView>
-      <Typography variant="h2">
-        {channelType !== ''
-          ? channelType
-          : variogramType !== ''
-          ? variogramType
-          : ''}{' '}
-        results
-      </Typography>
+      <Typography variant="h2">{type} results</Typography>
       <Styled.CaseResultList>
         {variogramResultList && (
           <VariogramResultTable

--- a/src/features/Results/CaseResult/CaseResultView/ObjectCaseResult/ChannelResult.tsx
+++ b/src/features/Results/CaseResult/CaseResultView/ObjectCaseResult/ChannelResult.tsx
@@ -34,7 +34,10 @@ export const ChannelResult = ({
           modelArea={modelArea}
           data={data}
         ></ResultArea>
-        <ChannelResultTable data={data}></ChannelResultTable>
+        <ChannelResultTable
+          data={data}
+          computeMethod={computeMethod}
+        ></ChannelResultTable>
       </Styled.InnerWrapper>
     </Styled.Wrapper>
   );

--- a/src/features/Results/CaseResult/CaseResultView/ObjectCaseResult/ChannelResultTable/ChannelResultTable.tsx
+++ b/src/features/Results/CaseResult/CaseResultView/ObjectCaseResult/ChannelResultTable/ChannelResultTable.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable max-lines-per-function */
 import { Table } from '@equinor/eds-core-react';
 
-import * as Styled from './ChannelResultTable.styled';
 import { GetObjectResultsDto } from '../../../../../../api/generated/models/GetObjectResultsDto';
+import * as Styled from './ChannelResultTable.styled';
 
 const NumberOfDecimals = 2;
 
-export const ChannelResultTable = ({ data }: { data: GetObjectResultsDto }) => {
+export const ChannelResultTable = ({
+  data,
+  computeMethod,
+}: {
+  data: GetObjectResultsDto;
+  computeMethod?: string;
+}) => {
   const roundResultString = (value?: number) => {
     if (value) {
       return value.toFixed(NumberOfDecimals);
@@ -25,7 +31,7 @@ export const ChannelResultTable = ({ data }: { data: GetObjectResultsDto }) => {
       </Table.Head>
       <Table.Body key={data.computeCaseId}>
         <Table.Row>
-          <Styled.ColumnCell>Channel width</Styled.ColumnCell>
+          <Styled.ColumnCell>{computeMethod} width</Styled.ColumnCell>
           <Styled.DataCell>
             {roundResultString(data.width?.mean)}
           </Styled.DataCell>
@@ -33,7 +39,7 @@ export const ChannelResultTable = ({ data }: { data: GetObjectResultsDto }) => {
           <Styled.DataCell>{data.width?.count}</Styled.DataCell>
         </Table.Row>
         <Table.Row>
-          <Styled.ColumnCell>Channel height</Styled.ColumnCell>
+          <Styled.ColumnCell>{computeMethod} height</Styled.ColumnCell>
           <Styled.DataCell>
             {roundResultString(data.height?.mean)}
           </Styled.DataCell>

--- a/src/pages/ModelPages/Results/ObjectResult/ObjectResult.tsx
+++ b/src/pages/ModelPages/Results/ObjectResult/ObjectResult.tsx
@@ -16,6 +16,7 @@ export const ObjectResult = () => {
         <CaseResultView
           channelResultList={objectResults}
           computeCases={cases.data?.data}
+          type="Object"
         />
       ) : (
         <NoResults />

--- a/src/pages/ModelPages/Results/VariogramResults/VariogramResults.tsx
+++ b/src/pages/ModelPages/Results/VariogramResults/VariogramResults.tsx
@@ -16,6 +16,7 @@ export const VariogramResults = () => {
         <CaseResultView
           variogramResultList={variogramResults}
           computeCases={cases.data?.data}
+          type="Variogram"
         />
       ) : (
         <NoResults />


### PR DESCRIPTION
Rename result type to reflect if it is a channel or mouthbar result. 