### PR TITLE
fix: Add back in horizontal scrollbar on model table.

### DIFF
--- a/src/features/ModelTable/ModelTable.styled.ts
+++ b/src/features/ModelTable/ModelTable.styled.ts
@@ -6,7 +6,7 @@ export const Table = styled.div`
   max-width: 1750px;
   > div {
     height: 100%;
-    overflow: hidden;
+    overflow-y: hidden;
     > table {
       min-width: 90% !important;
 


### PR DESCRIPTION
Add back scollbar removed in https://github.com/equinor/pepm-ui/pull/340