### PR TITLE
Fix: Variogram result dialog size

### DIFF
--- a/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.styled.ts
+++ b/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.styled.ts
@@ -3,47 +3,55 @@ import styled from 'styled-components';
 import { spacings } from '../../../../../../tokens/spacings';
 
 export const StyledDialog = styled(Dialog)`
-  width: min(1500px, 90vw);
-  height: min(1000px, 90vh);
+  --image-width: 1500px;
+  --image-height: 1000px;
+
+  width: min(var(--image-width), 90vw);
+  height: min(var(--image-height), 90vh);
   grid-template-rows: auto 52px;
-`;
 
-export const Content = styled(Dialog.CustomContent)`
-  display: flex;
-  flex-direction: column;
-  row-gap: ${spacings.SMALL};
-
-  .tabs {
+  .dialog-content {
     display: flex;
     flex-direction: column;
-    height: 100%;
-  }
+    row-gap: ${spacings.SMALL};
 
-  .tabs-panels {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
+    .tabs {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
 
-  .tabs-panel {
-    align-self: center;
+    .tabs-panels {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .tabs-panel {
+      align-self: center;
+    }
+
+    .image-wrapper {
+      margin: 0;
+    }
+
+    .image {
+      display: block;
+      width: 100%;
+      object-fit: contain;
+
+      /* Tweak the content height inside the dialog minus tabs, actions, padding, etc. */
+      max-height: calc(
+        min(var(--image-height), 90vh) -
+          (16px + 48px + 16px + 16px + 52px + 16px)
+      );
+    }
+
+    .placeholder-text {
+      text-align: center;
+    }
   }
 `;
 
 export { StyledDialog as Dialog };
-
-export const ImageWrapper = styled.div`
-  .image {
-    display: block;
-    width: 100%;
-    object-fit: contain;
-    max-height: calc(
-      min(1000px, 90vh) - 16px - 48px - 16px - 16px - 52px - 16px
-    ); /* Tweaking the height to match the content area minus patting, tab bars, action bar, etc. */
-  }
-
-  .placeholder-text {
-    text-align: center;
-  }
-`;

--- a/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.styled.ts
+++ b/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.styled.ts
@@ -2,52 +2,48 @@ import { Dialog } from '@equinor/eds-core-react';
 import styled from 'styled-components';
 import { spacings } from '../../../../../../tokens/spacings';
 
-import { theme } from '../../../../../../tokens/theme';
-
 export const StyledDialog = styled(Dialog)`
-  width: fit-content;
-  max-width: 90vw;
-  max-height: 90vh;
+  width: min(1500px, 90vw);
+  height: min(1000px, 90vh);
+  grid-template-rows: auto 52px;
 `;
 
 export const Content = styled(Dialog.CustomContent)`
   display: flex;
   flex-direction: column;
-
   row-gap: ${spacings.SMALL};
+
+  .tabs {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .tabs-panels {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .tabs-panel {
+    align-self: center;
+  }
 `;
 
 export { StyledDialog as Dialog };
 
 export const ImageWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  border-style: solid;
-  border-width: 1px;
-  border-color: ${theme.light.ui.background.medium};
-
-  > h5 {
-    font-weight: normal;
-    padding: ${spacings.SMALL};
+  .image {
+    display: block;
+    width: 100%;
+    object-fit: contain;
+    max-height: calc(
+      min(1000px, 90vh) - 16px - 48px - 16px - 16px - 52px - 16px
+    ); /* Tweaking the height to match the content area minus patting, tab bars, action bar, etc. */
   }
 
-  > .image {
-    width: fit-content;
-    max-width: 80vw;
-    max-height: 70vh;
-    padding: ${spacings.SMALL};
-
-    @media (max-width: 1200px) {
-      width: fit-content;
-      max-width: 70vw;
-      max-height: 60vh;
-    }
-    @media (max-width: 800px) {
-      width: fit-content;
-      max-width: 60vw;
-      max-height: 50vh;
-    }
+  .placeholder-text {
+    text-align: center;
   }
 `;

--- a/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
+++ b/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import {
   Button,
   CircularProgress,
@@ -11,90 +12,6 @@ import { getVariogramImage } from '../../../../../../api/custom/getImageById';
 import { GetVariogramResultsVariogramResultFileDto } from '../../../../../../api/generated';
 import * as Styled from './ImageResult.styled';
 
-type ImageType = {
-  id: string;
-  label: string;
-  searchTerm: string;
-  altText: string;
-};
-
-const IMAGE_TYPES: ImageType[] = [
-  {
-    id: 'variogram_slices',
-    label: 'Variogram slice',
-    searchTerm: 'variogram_slices_',
-    altText: 'Variogram x/y/z slice',
-  },
-  {
-    id: 'spherical',
-    label: 'Spherical',
-    searchTerm: 'spherical-',
-    altText: 'Spherical variogram',
-  },
-  {
-    id: 'gaussian',
-    label: 'Gaussian',
-    searchTerm: 'gaussian',
-    altText: 'Gaussian variogram',
-  },
-  {
-    id: 'general_exponential',
-    label: 'General exponential',
-    searchTerm: 'general_exponential',
-    altText: 'General exponential variogram',
-  },
-  {
-    id: 'exponential',
-    label: 'Exponential',
-    searchTerm: '-exponential',
-    altText: 'Exponential variogram',
-  },
-];
-
-const ImagePanel = ({
-  imageId,
-  altText,
-  label,
-}: {
-  imageId?: string;
-  altText: string;
-  label: string;
-}) => {
-  const { data, isLoading } = useQuery({
-    queryKey: ['case-image', imageId],
-    queryFn: () => getVariogramImage(imageId as string),
-    enabled: !!imageId,
-  });
-
-  if (!imageId || !data) {
-    return (
-      <figure className="image-wrapper">
-        <Typography variant="body_short" className="placeholder-text">
-          {label} variogram model is not included in the result
-        </Typography>
-      </figure>
-    );
-  }
-
-  return (
-    <>
-      {isLoading && (
-        <CircularProgress
-          color="primary"
-          size={24}
-          value={100}
-          variant="indeterminate"
-        />
-      )}
-      {data && (
-        <figure className="image-wrapper">
-          <img className="image" alt={altText} src={data} />
-        </figure>
-      )}
-    </>
-  );
-};
-
 export const ImageResult = ({
   open,
   setOpen,
@@ -105,31 +22,267 @@ export const ImageResult = ({
   resultImages: GetVariogramResultsVariogramResultFileDto[];
 }) => {
   const [activeTab, setActiveTab] = useState(0);
-
-  const getImageId = (searchTerm: string) => {
-    const image = resultImages?.find((x) => x.fileName.includes(searchTerm));
-    return image?.variogramResultFileId;
+  const handleChange = (index: number) => {
+    setActiveTab(index);
   };
+
+  const variogramSlices =
+    resultImages &&
+    resultImages.find((x) => x.fileName.includes('variogram_slices_'));
+  const variogramSlicesImageId =
+    variogramSlices && variogramSlices.variogramResultFileId;
+
+  const loadedVariogramSlicesImage = useQuery({
+    queryKey: ['case-image', variogramSlicesImageId],
+    queryFn: () => getVariogramImage(variogramSlicesImageId as string),
+    enabled: !!variogramSlicesImageId,
+  });
+
+  const sphericalImage =
+    resultImages && resultImages.find((x) => x.fileName.includes('spherical-'));
+  const sphericalImageId =
+    sphericalImage && sphericalImage.variogramResultFileId;
+
+  const loadedSphericalImage = useQuery({
+    queryKey: ['case-image', sphericalImageId],
+    queryFn: () => getVariogramImage(sphericalImageId as string),
+    enabled: !!sphericalImageId,
+  });
+
+  const gaussianImage =
+    resultImages && resultImages.find((x) => x.fileName.includes('gaussian'));
+  const gaussianImageId = gaussianImage && gaussianImage.variogramResultFileId;
+  const loadedGaussianImage = useQuery({
+    queryKey: ['case-image', gaussianImageId],
+    queryFn: () => getVariogramImage(gaussianImageId as string),
+    enabled: !!gaussianImageId,
+  });
+
+  const generalExponentialImage =
+    resultImages &&
+    resultImages.find((x) => x.fileName.includes('general_exponential'));
+  const generalExponentialImageId =
+    generalExponentialImage && generalExponentialImage.variogramResultFileId;
+  const loadedGeneralExponentialImage = useQuery({
+    queryKey: ['case-image', generalExponentialImageId],
+    queryFn: () => getVariogramImage(generalExponentialImageId as string),
+    enabled: !!generalExponentialImageId,
+  });
+
+  const exponentialImage =
+    resultImages &&
+    resultImages.find((x) => x.fileName.includes('-exponential'));
+  const exponentialImageId =
+    exponentialImage && exponentialImage.variogramResultFileId;
+  const loadedExponentialImage = useQuery({
+    queryKey: ['case-image', exponentialImageId],
+    queryFn: () => getVariogramImage(exponentialImageId as string),
+    enabled: !!exponentialImageId,
+  });
 
   return (
     <Styled.Dialog open={open} isDismissable>
       <Dialog.CustomContent className="dialog-content">
-        <Tabs activeTab={activeTab} onChange={setActiveTab} className="tabs">
+        <Tabs activeTab={activeTab} onChange={handleChange} className="tabs">
           <Tabs.List>
-            {IMAGE_TYPES.map(({ label }) => (
-              <Tabs.Tab key={label}>{label}</Tabs.Tab>
-            ))}
+            <Tabs.Tab>Variogram slice</Tabs.Tab>
+            <Tabs.Tab>Spherical</Tabs.Tab>
+            <Tabs.Tab>Gaussian</Tabs.Tab>
+            <Tabs.Tab>General Exponential</Tabs.Tab>
+            <Tabs.Tab>Exponential</Tabs.Tab>
           </Tabs.List>
           <Tabs.Panels className="tabs-panels">
-            {IMAGE_TYPES.map(({ id, searchTerm, altText, label }) => (
-              <Tabs.Panel key={id} className="tabs-panel">
-                <ImagePanel
-                  imageId={getImageId(searchTerm)}
-                  altText={altText}
-                  label={label}
-                />
-              </Tabs.Panel>
-            ))}
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedVariogramSlicesImage.isLoading && (
+                  <>
+                    <CircularProgress
+                      color="primary"
+                      size={24}
+                      value={100}
+                      variant="indeterminate"
+                    />
+                  </>
+                )}
+
+                {loadedVariogramSlicesImage.data && (
+                  <figure className="image-wrapper">
+                    <img
+                      className="image"
+                      alt="Variogram x/y/z slice"
+                      src={
+                        loadedVariogramSlicesImage.data
+                          ? loadedVariogramSlicesImage.data
+                          : ''
+                      }
+                    />
+                  </figure>
+                )}
+              </>
+            </Tabs.Panel>
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedSphericalImage && loadedSphericalImage.data ? (
+                  <>
+                    {loadedSphericalImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedSphericalImage.data && (
+                      <figure className="image-wrapper">
+                        <img
+                          className="image"
+                          alt="Spherical variogram (empirical and fitted)"
+                          src={
+                            loadedSphericalImage.data
+                              ? loadedSphericalImage.data
+                              : ''
+                          }
+                        />
+                      </figure>
+                    )}
+                  </>
+                ) : (
+                  <figure className="image-wrapper">
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      Spherical variogram model is not included in the result
+                    </Typography>
+                  </figure>
+                )}
+              </>
+            </Tabs.Panel>
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedGaussianImage && loadedGaussianImage.data ? (
+                  <>
+                    {loadedGaussianImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedGaussianImage.data && (
+                      <figure className="image-wrapper">
+                        <img
+                          className="image"
+                          alt="Gaussian variogram (empirical and fitted)"
+                          src={
+                            loadedGaussianImage.data
+                              ? loadedGaussianImage.data
+                              : ''
+                          }
+                        />
+                      </figure>
+                    )}
+                  </>
+                ) : (
+                  <figure className="image-wrapper">
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      Gaussian variogram model is not included in the result
+                    </Typography>
+                  </figure>
+                )}
+              </>
+            </Tabs.Panel>
+
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedGeneralExponentialImage &&
+                loadedGeneralExponentialImage.data ? (
+                  <>
+                    {loadedGeneralExponentialImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedGeneralExponentialImage.data && (
+                      <figure className="image-wrapper">
+                        <img
+                          className="image"
+                          alt="General Exponential variogram (empirical and fitted)"
+                          src={
+                            loadedGeneralExponentialImage.data
+                              ? loadedGeneralExponentialImage.data
+                              : ''
+                          }
+                        />
+                      </figure>
+                    )}
+                  </>
+                ) : (
+                  <figure className="image-wrapper">
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      General exponential variogram model is not included in the
+                      result
+                    </Typography>
+                  </figure>
+                )}
+              </>
+            </Tabs.Panel>
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedExponentialImage && loadedExponentialImage.data ? (
+                  <>
+                    {loadedExponentialImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedExponentialImage.data && (
+                      <figure className="image-wrapper">
+                        <img
+                          className="image"
+                          alt="Exponential variogram (empirical and fitted)"
+                          src={
+                            loadedExponentialImage.data
+                              ? loadedExponentialImage.data
+                              : ''
+                          }
+                        />
+                      </figure>
+                    )}
+                  </>
+                ) : (
+                  <figure className="image-wrapper">
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      Exponential variogram model is not included in the result
+                    </Typography>
+                  </figure>
+                )}
+              </>
+            </Tabs.Panel>
           </Tabs.Panels>
         </Tabs>
       </Dialog.CustomContent>

--- a/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
+++ b/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import {
   Button,
   CircularProgress,
@@ -12,6 +11,90 @@ import { getVariogramImage } from '../../../../../../api/custom/getImageById';
 import { GetVariogramResultsVariogramResultFileDto } from '../../../../../../api/generated';
 import * as Styled from './ImageResult.styled';
 
+type ImageType = {
+  id: string;
+  label: string;
+  searchTerm: string;
+  altText: string;
+};
+
+const IMAGE_TYPES: ImageType[] = [
+  {
+    id: 'variogram_slices',
+    label: 'Variogram slice',
+    searchTerm: 'variogram_slices_',
+    altText: 'Variogram x/y/z slice',
+  },
+  {
+    id: 'spherical',
+    label: 'Spherical',
+    searchTerm: 'spherical-',
+    altText: 'Spherical variogram',
+  },
+  {
+    id: 'gaussian',
+    label: 'Gaussian',
+    searchTerm: 'gaussian',
+    altText: 'Gaussian variogram',
+  },
+  {
+    id: 'general_exponential',
+    label: 'General exponential',
+    searchTerm: 'general_exponential',
+    altText: 'General exponential variogram',
+  },
+  {
+    id: 'exponential',
+    label: 'Exponential',
+    searchTerm: '-exponential',
+    altText: 'Exponential variogram',
+  },
+];
+
+const ImagePanel = ({
+  imageId,
+  altText,
+  label,
+}: {
+  imageId?: string;
+  altText: string;
+  label: string;
+}) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['case-image', imageId],
+    queryFn: () => getVariogramImage(imageId as string),
+    enabled: !!imageId,
+  });
+
+  if (!imageId || !data) {
+    return (
+      <figure className="image-wrapper">
+        <Typography variant="body_short" className="placeholder-text">
+          {label} variogram model is not included in the result
+        </Typography>
+      </figure>
+    );
+  }
+
+  return (
+    <>
+      {isLoading && (
+        <CircularProgress
+          color="primary"
+          size={24}
+          value={100}
+          variant="indeterminate"
+        />
+      )}
+      {data && (
+        <figure className="image-wrapper">
+          <img className="image" alt={altText} src={data} />
+        </figure>
+      )}
+    </>
+  );
+};
+
 export const ImageResult = ({
   open,
   setOpen,
@@ -22,267 +105,31 @@ export const ImageResult = ({
   resultImages: GetVariogramResultsVariogramResultFileDto[];
 }) => {
   const [activeTab, setActiveTab] = useState(0);
-  const handleChange = (index: number) => {
-    setActiveTab(index);
+
+  const getImageId = (searchTerm: string) => {
+    const image = resultImages?.find((x) => x.fileName.includes(searchTerm));
+    return image?.variogramResultFileId;
   };
-
-  const variogramSlices =
-    resultImages &&
-    resultImages.find((x) => x.fileName.includes('variogram_slices_'));
-  const variogramSlicesImageId =
-    variogramSlices && variogramSlices.variogramResultFileId;
-
-  const loadedVariogramSlicesImage = useQuery({
-    queryKey: ['case-image', variogramSlicesImageId],
-    queryFn: () => getVariogramImage(variogramSlicesImageId as string),
-    enabled: !!variogramSlicesImageId,
-  });
-
-  const sphericalImage =
-    resultImages && resultImages.find((x) => x.fileName.includes('spherical-'));
-  const sphericalImageId =
-    sphericalImage && sphericalImage.variogramResultFileId;
-
-  const loadedSphericalImage = useQuery({
-    queryKey: ['case-image', sphericalImageId],
-    queryFn: () => getVariogramImage(sphericalImageId as string),
-    enabled: !!sphericalImageId,
-  });
-
-  const gaussianImage =
-    resultImages && resultImages.find((x) => x.fileName.includes('gaussian'));
-  const gaussianImageId = gaussianImage && gaussianImage.variogramResultFileId;
-  const loadedGaussianImage = useQuery({
-    queryKey: ['case-image', gaussianImageId],
-    queryFn: () => getVariogramImage(gaussianImageId as string),
-    enabled: !!gaussianImageId,
-  });
-
-  const generalExponentialImage =
-    resultImages &&
-    resultImages.find((x) => x.fileName.includes('general_exponential'));
-  const generalExponentialImageId =
-    generalExponentialImage && generalExponentialImage.variogramResultFileId;
-  const loadedGeneralExponentialImage = useQuery({
-    queryKey: ['case-image', generalExponentialImageId],
-    queryFn: () => getVariogramImage(generalExponentialImageId as string),
-    enabled: !!generalExponentialImageId,
-  });
-
-  const exponentialImage =
-    resultImages &&
-    resultImages.find((x) => x.fileName.includes('-exponential'));
-  const exponentialImageId =
-    exponentialImage && exponentialImage.variogramResultFileId;
-  const loadedExponentialImage = useQuery({
-    queryKey: ['case-image', exponentialImageId],
-    queryFn: () => getVariogramImage(exponentialImageId as string),
-    enabled: !!exponentialImageId,
-  });
 
   return (
     <Styled.Dialog open={open} isDismissable>
       <Dialog.CustomContent className="dialog-content">
-        <Tabs activeTab={activeTab} onChange={handleChange} className="tabs">
+        <Tabs activeTab={activeTab} onChange={setActiveTab} className="tabs">
           <Tabs.List>
-            <Tabs.Tab>Variogram slice</Tabs.Tab>
-            <Tabs.Tab>Spherical</Tabs.Tab>
-            <Tabs.Tab>Gaussian</Tabs.Tab>
-            <Tabs.Tab>General Exponential</Tabs.Tab>
-            <Tabs.Tab>Exponential</Tabs.Tab>
+            {IMAGE_TYPES.map(({ label }) => (
+              <Tabs.Tab key={label}>{label}</Tabs.Tab>
+            ))}
           </Tabs.List>
           <Tabs.Panels className="tabs-panels">
-            <Tabs.Panel className="tabs-panel">
-              <>
-                {loadedVariogramSlicesImage.isLoading && (
-                  <>
-                    <CircularProgress
-                      color="primary"
-                      size={24}
-                      value={100}
-                      variant="indeterminate"
-                    />
-                  </>
-                )}
-
-                {loadedVariogramSlicesImage.data && (
-                  <figure className="image-wrapper">
-                    <img
-                      className="image"
-                      alt="Variogram x/y/z slice"
-                      src={
-                        loadedVariogramSlicesImage.data
-                          ? loadedVariogramSlicesImage.data
-                          : ''
-                      }
-                    />
-                  </figure>
-                )}
-              </>
-            </Tabs.Panel>
-            <Tabs.Panel className="tabs-panel">
-              <>
-                {loadedSphericalImage && loadedSphericalImage.data ? (
-                  <>
-                    {loadedSphericalImage.isLoading && (
-                      <>
-                        <CircularProgress
-                          color="primary"
-                          size={24}
-                          value={100}
-                          variant="indeterminate"
-                        />
-                      </>
-                    )}
-                    {loadedSphericalImage.data && (
-                      <figure className="image-wrapper">
-                        <img
-                          className="image"
-                          alt="Spherical variogram (empirical and fitted)"
-                          src={
-                            loadedSphericalImage.data
-                              ? loadedSphericalImage.data
-                              : ''
-                          }
-                        />
-                      </figure>
-                    )}
-                  </>
-                ) : (
-                  <figure className="image-wrapper">
-                    <Typography
-                      variant="body_short"
-                      className="placeholder-text"
-                    >
-                      Spherical variogram model is not included in the result
-                    </Typography>
-                  </figure>
-                )}
-              </>
-            </Tabs.Panel>
-            <Tabs.Panel className="tabs-panel">
-              <>
-                {loadedGaussianImage && loadedGaussianImage.data ? (
-                  <>
-                    {loadedGaussianImage.isLoading && (
-                      <>
-                        <CircularProgress
-                          color="primary"
-                          size={24}
-                          value={100}
-                          variant="indeterminate"
-                        />
-                      </>
-                    )}
-                    {loadedGaussianImage.data && (
-                      <figure className="image-wrapper">
-                        <img
-                          className="image"
-                          alt="Gaussian variogram (empirical and fitted)"
-                          src={
-                            loadedGaussianImage.data
-                              ? loadedGaussianImage.data
-                              : ''
-                          }
-                        />
-                      </figure>
-                    )}
-                  </>
-                ) : (
-                  <figure className="image-wrapper">
-                    <Typography
-                      variant="body_short"
-                      className="placeholder-text"
-                    >
-                      Gaussian variogram model is not included in the result
-                    </Typography>
-                  </figure>
-                )}
-              </>
-            </Tabs.Panel>
-
-            <Tabs.Panel className="tabs-panel">
-              <>
-                {loadedGeneralExponentialImage &&
-                loadedGeneralExponentialImage.data ? (
-                  <>
-                    {loadedGeneralExponentialImage.isLoading && (
-                      <>
-                        <CircularProgress
-                          color="primary"
-                          size={24}
-                          value={100}
-                          variant="indeterminate"
-                        />
-                      </>
-                    )}
-                    {loadedGeneralExponentialImage.data && (
-                      <figure className="image-wrapper">
-                        <img
-                          className="image"
-                          alt="General Exponential variogram (empirical and fitted)"
-                          src={
-                            loadedGeneralExponentialImage.data
-                              ? loadedGeneralExponentialImage.data
-                              : ''
-                          }
-                        />
-                      </figure>
-                    )}
-                  </>
-                ) : (
-                  <figure className="image-wrapper">
-                    <Typography
-                      variant="body_short"
-                      className="placeholder-text"
-                    >
-                      General exponential variogram model is not included in the
-                      result
-                    </Typography>
-                  </figure>
-                )}
-              </>
-            </Tabs.Panel>
-            <Tabs.Panel className="tabs-panel">
-              <>
-                {loadedExponentialImage && loadedExponentialImage.data ? (
-                  <>
-                    {loadedExponentialImage.isLoading && (
-                      <>
-                        <CircularProgress
-                          color="primary"
-                          size={24}
-                          value={100}
-                          variant="indeterminate"
-                        />
-                      </>
-                    )}
-                    {loadedExponentialImage.data && (
-                      <figure className="image-wrapper">
-                        <img
-                          className="image"
-                          alt="Exponential variogram (empirical and fitted)"
-                          src={
-                            loadedExponentialImage.data
-                              ? loadedExponentialImage.data
-                              : ''
-                          }
-                        />
-                      </figure>
-                    )}
-                  </>
-                ) : (
-                  <figure className="image-wrapper">
-                    <Typography
-                      variant="body_short"
-                      className="placeholder-text"
-                    >
-                      Exponential variogram model is not included in the result
-                    </Typography>
-                  </figure>
-                )}
-              </>
-            </Tabs.Panel>
+            {IMAGE_TYPES.map(({ id, searchTerm, altText, label }) => (
+              <Tabs.Panel key={id} className="tabs-panel">
+                <ImagePanel
+                  imageId={getImageId(searchTerm)}
+                  altText={altText}
+                  label={label}
+                />
+              </Tabs.Panel>
+            ))}
           </Tabs.Panels>
         </Tabs>
       </Dialog.CustomContent>

--- a/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
+++ b/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable max-lines-per-function */
-import { Button, Dialog, Tabs } from '@equinor/eds-core-react';
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  Tabs,
+  Typography,
+} from '@equinor/eds-core-react';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { getVariogramImage } from '../../../../../../api/custom/getImageById';
@@ -77,7 +83,7 @@ export const ImageResult = ({
   return (
     <Styled.Dialog open={open} isDismissable>
       <Styled.Content>
-        <Tabs activeTab={activeTab} onChange={handleChange}>
+        <Tabs activeTab={activeTab} onChange={handleChange} className="tabs">
           <Tabs.List>
             <Tabs.Tab>Variogram slice</Tabs.Tab>
             <Tabs.Tab>Spherical</Tabs.Tab>
@@ -85,121 +91,205 @@ export const ImageResult = ({
             <Tabs.Tab>General Exponential</Tabs.Tab>
             <Tabs.Tab>Exponential</Tabs.Tab>
           </Tabs.List>
-          <Tabs.Panels>
-            <Tabs.Panel>
-              {loadedVariogramSlicesImage.isLoading && <>Loading ...</>}
+          <Tabs.Panels className="tabs-panels">
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedVariogramSlicesImage.isLoading && (
+                  <>
+                    <CircularProgress
+                      color="primary"
+                      size={24}
+                      value={100}
+                      variant="indeterminate"
+                    />
+                  </>
+                )}
 
-              {loadedVariogramSlicesImage.data && (
-                <Styled.ImageWrapper>
-                  <img
-                    className="image"
-                    alt="Case results"
-                    src={
-                      loadedVariogramSlicesImage.data
-                        ? loadedVariogramSlicesImage.data
-                        : ''
-                    }
-                  />
-                </Styled.ImageWrapper>
-              )}
+                {loadedVariogramSlicesImage.data && (
+                  <Styled.ImageWrapper>
+                    <img
+                      className="image"
+                      alt="Case results"
+                      src={
+                        loadedVariogramSlicesImage.data
+                          ? loadedVariogramSlicesImage.data
+                          : ''
+                      }
+                    />
+                  </Styled.ImageWrapper>
+                )}
+              </>
             </Tabs.Panel>
-            <Tabs.Panel>
-              {loadedSphericalImage && loadedSphericalImage.data ? (
-                <>
-                  {loadedSphericalImage.isLoading && <>Loading ...</>}
-                  {loadedSphericalImage.data && (
-                    <Styled.ImageWrapper>
-                      <img
-                        className="image"
-                        alt="Spherical"
-                        src={
-                          loadedSphericalImage.data
-                            ? loadedSphericalImage.data
-                            : ''
-                        }
-                      />
-                    </Styled.ImageWrapper>
-                  )}
-                </>
-              ) : (
-                <>No Spherical</>
-              )}
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedSphericalImage && loadedSphericalImage.data ? (
+                  <>
+                    {loadedSphericalImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedSphericalImage.data && (
+                      <Styled.ImageWrapper>
+                        <img
+                          className="image"
+                          alt="Spherical"
+                          src={
+                            loadedSphericalImage.data
+                              ? loadedSphericalImage.data
+                              : ''
+                          }
+                        />
+                      </Styled.ImageWrapper>
+                    )}
+                  </>
+                ) : (
+                  <Styled.ImageWrapper>
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      Spherical variogram model is not included in the result
+                    </Typography>
+                  </Styled.ImageWrapper>
+                )}
+              </>
             </Tabs.Panel>
-            <Tabs.Panel>
-              {loadedGaussianImage && loadedGaussianImage.data ? (
-                <>
-                  {loadedGaussianImage.isLoading && <>Loading ...</>}
-                  {loadedGaussianImage.data && (
-                    <Styled.ImageWrapper>
-                      <img
-                        className="image"
-                        alt="Gaussian"
-                        src={
-                          loadedGaussianImage.data
-                            ? loadedGaussianImage.data
-                            : ''
-                        }
-                      />
-                    </Styled.ImageWrapper>
-                  )}
-                </>
-              ) : (
-                <>No Gaussian</>
-              )}
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedGaussianImage && loadedGaussianImage.data ? (
+                  <>
+                    {loadedGaussianImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedGaussianImage.data && (
+                      <Styled.ImageWrapper>
+                        <img
+                          className="image"
+                          alt="Gaussian"
+                          src={
+                            loadedGaussianImage.data
+                              ? loadedGaussianImage.data
+                              : ''
+                          }
+                        />
+                      </Styled.ImageWrapper>
+                    )}
+                  </>
+                ) : (
+                  <Styled.ImageWrapper>
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      Gaussian variogram model is not included in the result
+                    </Typography>
+                  </Styled.ImageWrapper>
+                )}
+              </>
             </Tabs.Panel>
 
-            <Tabs.Panel>
-              {loadedGeneralExponentialImage &&
-              loadedGeneralExponentialImage.data ? (
-                <>
-                  {loadedGeneralExponentialImage.isLoading && <>Loading ...</>}
-                  {loadedGeneralExponentialImage.data && (
-                    <Styled.ImageWrapper>
-                      <img
-                        className="image"
-                        alt="General Exponential"
-                        src={
-                          loadedGeneralExponentialImage.data
-                            ? loadedGeneralExponentialImage.data
-                            : ''
-                        }
-                      />
-                    </Styled.ImageWrapper>
-                  )}
-                </>
-              ) : (
-                <>No General Exponential</>
-              )}
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedGeneralExponentialImage &&
+                loadedGeneralExponentialImage.data ? (
+                  <>
+                    {loadedGeneralExponentialImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedGeneralExponentialImage.data && (
+                      <Styled.ImageWrapper>
+                        <img
+                          className="image"
+                          alt="General Exponential"
+                          src={
+                            loadedGeneralExponentialImage.data
+                              ? loadedGeneralExponentialImage.data
+                              : ''
+                          }
+                        />
+                      </Styled.ImageWrapper>
+                    )}
+                  </>
+                ) : (
+                  <Styled.ImageWrapper>
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      General exponential variogram model is not included in the
+                      result
+                    </Typography>
+                  </Styled.ImageWrapper>
+                )}
+              </>
             </Tabs.Panel>
-            <Tabs.Panel>
-              {loadedExponentialImage && loadedExponentialImage.data ? (
-                <>
-                  {loadedExponentialImage.isLoading && <>Loading ...</>}
-                  {loadedExponentialImage.data && (
-                    <Styled.ImageWrapper>
-                      <img
-                        className="image"
-                        alt="Exponential"
-                        src={
-                          loadedExponentialImage.data
-                            ? loadedExponentialImage.data
-                            : ''
-                        }
-                      />
-                    </Styled.ImageWrapper>
-                  )}
-                </>
-              ) : (
-                <>No General Exponential</>
-              )}
+            <Tabs.Panel className="tabs-panel">
+              <>
+                {loadedExponentialImage && loadedExponentialImage.data ? (
+                  <>
+                    {loadedExponentialImage.isLoading && (
+                      <>
+                        <CircularProgress
+                          color="primary"
+                          size={24}
+                          value={100}
+                          variant="indeterminate"
+                        />
+                      </>
+                    )}
+                    {loadedExponentialImage.data && (
+                      <Styled.ImageWrapper>
+                        <img
+                          className="image"
+                          alt="Exponential"
+                          src={
+                            loadedExponentialImage.data
+                              ? loadedExponentialImage.data
+                              : ''
+                          }
+                        />
+                      </Styled.ImageWrapper>
+                    )}
+                  </>
+                ) : (
+                  <Styled.ImageWrapper>
+                    <Typography
+                      variant="body_short"
+                      className="placeholder-text"
+                    >
+                      Exponential variogram model is not included in the result
+                    </Typography>
+                  </Styled.ImageWrapper>
+                )}
+              </>
             </Tabs.Panel>
           </Tabs.Panels>
         </Tabs>
       </Styled.Content>
 
       <Dialog.Actions>
-        <Button variant="ghost" onClick={() => setOpen(!open)}>
-          Close
+        <Button variant="contained" onClick={() => setOpen(!open)}>
+          Close this window
         </Button>
       </Dialog.Actions>
     </Styled.Dialog>

--- a/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
+++ b/src/features/Results/CaseResult/CaseResultView/VariogramCaseResult/ImageResult/ImageResult.tsx
@@ -82,7 +82,7 @@ export const ImageResult = ({
 
   return (
     <Styled.Dialog open={open} isDismissable>
-      <Styled.Content>
+      <Dialog.CustomContent className="dialog-content">
         <Tabs activeTab={activeTab} onChange={handleChange} className="tabs">
           <Tabs.List>
             <Tabs.Tab>Variogram slice</Tabs.Tab>
@@ -106,17 +106,17 @@ export const ImageResult = ({
                 )}
 
                 {loadedVariogramSlicesImage.data && (
-                  <Styled.ImageWrapper>
+                  <figure className="image-wrapper">
                     <img
                       className="image"
-                      alt="Case results"
+                      alt="Variogram x/y/z slice"
                       src={
                         loadedVariogramSlicesImage.data
                           ? loadedVariogramSlicesImage.data
                           : ''
                       }
                     />
-                  </Styled.ImageWrapper>
+                  </figure>
                 )}
               </>
             </Tabs.Panel>
@@ -135,28 +135,28 @@ export const ImageResult = ({
                       </>
                     )}
                     {loadedSphericalImage.data && (
-                      <Styled.ImageWrapper>
+                      <figure className="image-wrapper">
                         <img
                           className="image"
-                          alt="Spherical"
+                          alt="Spherical variogram (empirical and fitted)"
                           src={
                             loadedSphericalImage.data
                               ? loadedSphericalImage.data
                               : ''
                           }
                         />
-                      </Styled.ImageWrapper>
+                      </figure>
                     )}
                   </>
                 ) : (
-                  <Styled.ImageWrapper>
+                  <figure className="image-wrapper">
                     <Typography
                       variant="body_short"
                       className="placeholder-text"
                     >
                       Spherical variogram model is not included in the result
                     </Typography>
-                  </Styled.ImageWrapper>
+                  </figure>
                 )}
               </>
             </Tabs.Panel>
@@ -175,28 +175,28 @@ export const ImageResult = ({
                       </>
                     )}
                     {loadedGaussianImage.data && (
-                      <Styled.ImageWrapper>
+                      <figure className="image-wrapper">
                         <img
                           className="image"
-                          alt="Gaussian"
+                          alt="Gaussian variogram (empirical and fitted)"
                           src={
                             loadedGaussianImage.data
                               ? loadedGaussianImage.data
                               : ''
                           }
                         />
-                      </Styled.ImageWrapper>
+                      </figure>
                     )}
                   </>
                 ) : (
-                  <Styled.ImageWrapper>
+                  <figure className="image-wrapper">
                     <Typography
                       variant="body_short"
                       className="placeholder-text"
                     >
                       Gaussian variogram model is not included in the result
                     </Typography>
-                  </Styled.ImageWrapper>
+                  </figure>
                 )}
               </>
             </Tabs.Panel>
@@ -217,21 +217,21 @@ export const ImageResult = ({
                       </>
                     )}
                     {loadedGeneralExponentialImage.data && (
-                      <Styled.ImageWrapper>
+                      <figure className="image-wrapper">
                         <img
                           className="image"
-                          alt="General Exponential"
+                          alt="General Exponential variogram (empirical and fitted)"
                           src={
                             loadedGeneralExponentialImage.data
                               ? loadedGeneralExponentialImage.data
                               : ''
                           }
                         />
-                      </Styled.ImageWrapper>
+                      </figure>
                     )}
                   </>
                 ) : (
-                  <Styled.ImageWrapper>
+                  <figure className="image-wrapper">
                     <Typography
                       variant="body_short"
                       className="placeholder-text"
@@ -239,7 +239,7 @@ export const ImageResult = ({
                       General exponential variogram model is not included in the
                       result
                     </Typography>
-                  </Styled.ImageWrapper>
+                  </figure>
                 )}
               </>
             </Tabs.Panel>
@@ -258,34 +258,34 @@ export const ImageResult = ({
                       </>
                     )}
                     {loadedExponentialImage.data && (
-                      <Styled.ImageWrapper>
+                      <figure className="image-wrapper">
                         <img
                           className="image"
-                          alt="Exponential"
+                          alt="Exponential variogram (empirical and fitted)"
                           src={
                             loadedExponentialImage.data
                               ? loadedExponentialImage.data
                               : ''
                           }
                         />
-                      </Styled.ImageWrapper>
+                      </figure>
                     )}
                   </>
                 ) : (
-                  <Styled.ImageWrapper>
+                  <figure className="image-wrapper">
                     <Typography
                       variant="body_short"
                       className="placeholder-text"
                     >
                       Exponential variogram model is not included in the result
                     </Typography>
-                  </Styled.ImageWrapper>
+                  </figure>
                 )}
               </>
             </Tabs.Panel>
           </Tabs.Panels>
         </Tabs>
-      </Styled.Content>
+      </Dialog.CustomContent>
 
       <Dialog.Actions>
         <Button variant="contained" onClick={() => setOpen(!open)}>


### PR DESCRIPTION
- Set a responsive size to the variogram slice dialog that works for results with and without all variogram models.
- Add a loading indicator when the images are loading.
- Add a custom text when variogram models are missing.
- Make the close button more visible.

~~Experimental:~~
~~- Refactor the page to avoid repetition (used Claude AI, needs some developer eyes to verify)~~

Closes #398 