### PR TITLE
fix: Loading indicator on object and variogram result

### DIFF
--- a/src/App.styled.tsx
+++ b/src/App.styled.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const StyledOutletWrapper = styled.section`
+const StyledOutletWrapper = styled.div`
   height: calc(100% - 128px);
   overflow: auto;
 `;

--- a/src/features/HandleModel/SidePane/SidePane.styled.ts
+++ b/src/features/HandleModel/SidePane/SidePane.styled.ts
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import { spacings } from '../../../tokens/spacings';
 import { theme } from '../../../tokens/theme';
 
-export const SidebarWrapper = styled.div`
-  heigth: 100%;
+export const SidebarWrapper = styled.aside`
+  height: 100%;
   max-width: 256px;
 `;
 

--- a/src/pages/AddModel/AddModel.styled.tsx
+++ b/src/pages/AddModel/AddModel.styled.tsx
@@ -8,7 +8,7 @@ export const PageLayout = styled.div`
   height: 100%;
 `;
 
-export const Content = styled.div`
+export const Content = styled.main`
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/pages/Browse/Browse.styled.tsx
+++ b/src/pages/Browse/Browse.styled.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { spacings } from '../../tokens/spacings';
 
-export const BrowseWrapper = styled.div`
+export const BrowseWrapper = styled.main`
   column-gap: ${spacings.X_LARGE};
   padding: ${spacings.XXX_LARGE} ${spacings.X_LARGE};
 

--- a/src/pages/ModelPages/Model/Model.styled.tsx
+++ b/src/pages/ModelPages/Model/Model.styled.tsx
@@ -20,12 +20,15 @@ export const Wrapper = styled.div`
   display: grid;
   grid-template-areas: 'sidebar content';
   grid-template-columns: 16rem 1fr;
+  height: 100%;
 `;
 
-export const ContentWrapper = styled.div`
+export const ContentWrapper = styled.main`
   grid-area: content;
+  display: flex;
+  flex-flow: column nowrap;
 `;
 
-export const SidebarWrapper = styled.div`
+export const SidebarWrapper = styled.aside`
   grid-area: sidebar;
 `;

--- a/src/pages/ModelPages/Model/Model.tsx
+++ b/src/pages/ModelPages/Model/Model.tsx
@@ -132,7 +132,7 @@ export const Model = () => {
             size={24}
             value={100}
             variant="indeterminate"
-          />{' '}
+          />
           <Typography variant="body_short">Loading, please wait…</Typography>
         </div>
       </Styled.EmptyPage>

--- a/src/pages/ModelPages/Results/ObjectResult/ObjectResult.tsx
+++ b/src/pages/ModelPages/Results/ObjectResult/ObjectResult.tsx
@@ -3,6 +3,8 @@ import { NoResults } from '../../../../features/Results/NoResults/NoResults';
 import { useFetchObjectResults } from '../../../../hooks/useFetchChannelResults';
 import { usePepmContextStore } from '../../../../hooks/GlobalState';
 import { useEffect } from 'react';
+import { CircularProgress, Typography } from '@equinor/eds-core-react';
+import * as Styled from '../../Model/Model.styled';
 
 export const ObjectResult = () => {
   const { computeCases, objectResults, setObjectEstimationResults } =
@@ -13,7 +15,20 @@ export const ObjectResult = () => {
     if (data) setObjectEstimationResults(data.data);
   }, [data, setObjectEstimationResults]);
 
-  if (isLoading) return <>Loading ...</>;
+  if (isLoading)
+    return (
+      <Styled.EmptyPage>
+        <div className="loading">
+          <CircularProgress
+            color="primary"
+            size={24}
+            value={100}
+            variant="indeterminate"
+          />
+          <Typography variant="body_short">Loading, please wait…</Typography>
+        </div>
+      </Styled.EmptyPage>
+    );
 
   return (
     <>

--- a/src/pages/ModelPages/Results/VariogramResults/VariogramResults.tsx
+++ b/src/pages/ModelPages/Results/VariogramResults/VariogramResults.tsx
@@ -3,6 +3,8 @@ import { CaseResultView } from '../../../../features/Results/CaseResult/CaseResu
 import { NoResults } from '../../../../features/Results/NoResults/NoResults';
 import { usePepmContextStore } from '../../../../hooks/GlobalState';
 import { useFetchVariogramResults } from '../../../../hooks/useFetchVariogramResults';
+import { CircularProgress, Typography } from '@equinor/eds-core-react';
+import * as Styled from '../../Model/Model.styled';
 
 export const VariogramResults = () => {
   const { data, isLoading } = useFetchVariogramResults();
@@ -13,7 +15,20 @@ export const VariogramResults = () => {
     if (data) setVariogramResults(data.data);
   }, [data, setVariogramResults]);
 
-  if (isLoading) return <>Loading ...</>;
+  if (isLoading)
+    return (
+      <Styled.EmptyPage>
+        <div className="loading">
+          <CircularProgress
+            color="primary"
+            size={24}
+            value={100}
+            variant="indeterminate"
+          />
+          <Typography variant="body_short">Loading, please wait…</Typography>
+        </div>
+      </Styled.EmptyPage>
+    );
 
   return (
     <>


### PR DESCRIPTION
This PR will

- Add an animated loading indicator to the object- and variogram result pages
- Minimally improve HTML semantics
- Fix a typo
- Set the model page to full height (this is only visible on the loading state, where the gray background would only cover half of the page)

Closes #400

**Note**: There are still multiple instances of the static "Loading ..." text in the application that could be improved, but I was not able to trigger and test them all.