### PR TITLE
fix: form validation runs when submitting the form and not on page load

### DIFF
--- a/src/features/HandleModel/HandleModelComponent/HandleModelComponent.tsx
+++ b/src/features/HandleModel/HandleModelComponent/HandleModelComponent.tsx
@@ -138,7 +138,9 @@ export const HandleModelComponent = () => {
   });
 
   async function handleSubmit() {
-    setSubmitErrors(validateValues(analogueModel, files));
+    const validationErrors = validateValues(analogueModel, files);
+    setSubmitErrors(validationErrors);
+
     if (
       Object.keys(submitErrors).length === 0 &&
       fileErrors.length === 0 &&
@@ -317,10 +319,6 @@ export const HandleModelComponent = () => {
       resetFileErrors();
     }
   }, [files, iniFileString, addErrors, addFileErrors, resetFileErrors]);
-
-  useEffect(() => {
-    setSubmitErrors(validateValues(analogueModel, files));
-  }, [setAnalogueModel, setSubmitErrors, analogueModel, files]);
 
   return (
     <Styled.Wrapper>


### PR DESCRIPTION
The previous implementation triggered validation inside a `useEffect`, causing error messages to appear immediately when the page loaded or when form fields changed.

### How to test
- Click "Add new model"
- Check that no error messages are visible when the page loads
- Leave the form blank and click "Confirm and start uploading"
- Check that the error validation is now visible
- Test various combinations and see that the validation still works (name only, description only, files only, etc.)

<img width="827" height="731" alt="image" src="https://github.com/user-attachments/assets/a43b9240-3b7e-4329-80ba-9b9bdbd1d995" />
